### PR TITLE
Only target full Framework when built on Windows

### DIFF
--- a/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
+++ b/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
@@ -1,10 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>Agoda</Authors>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Description>Agoda.Frameworks.DB</Description>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
+++ b/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
@@ -1,12 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Authors>Agoda</Authors>
     <Product>Agoda.Frameworks.Http</Product>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.Http</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
+++ b/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
@@ -1,11 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Authors>Agoda</Authors>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.LoadBalancing</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While I'm not sure why do we even need to target `net462` as a target framework, doing so makes the build of these projects fail on systems that do not have full .Net Framework, making it more difficult for people not using Windows to contribute:
![image](https://user-images.githubusercontent.com/5929156/57005536-f654d580-6c02-11e9-903c-6de10222d65a.png)

One potential solution would be that I remove it on my Mac and remember that I should not commit that change. A better one might be the one proposed by this PR: add a condition to the `TargetFramework` property to only build `net462` if it's being built on Windows.

As a result, now the build succeeds on Mac, for example, as it will only build agains .Net Standard:
![image](https://user-images.githubusercontent.com/5929156/57005597-56e41280-6c03-11e9-93e7-a3ad6ade0328.png)

But at the same time, if you build it on Windows, the results will be the same (note how the class libraries are being built both into `\Debug\netstandard2.0` and `\Debug\net462`:
![image](https://user-images.githubusercontent.com/5929156/57005620-8a26a180-6c03-11e9-9c56-bc7eb1579d67.png)

Since the CI builds use Windows machines, they should continue to publish both versions to NuGet, too.