### PR TITLE
Update grpc version

### DIFF
--- a/Agoda.Frameworks.Grpc.Tests/Agoda.Frameworks.Grpc.Tests.csproj
+++ b/Agoda.Frameworks.Grpc.Tests/Agoda.Frameworks.Grpc.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.9.1" />
-    <PackageReference Include="Grpc.Tools" Version="1.22.0">
+    <PackageReference Include="Grpc.Tools" Version="2.23.0">
     <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
+++ b/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Grpc.Core" Version="1.22.0" />
+	<PackageReference Include="Grpc.Core" Version="2.23.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Recently gRPC just updated their major version for c#
https://github.com/grpc/grpc/releases/tag/v1.23.0

The proposal for this release can be accessed here
https://github.com/grpc/proposal/blob/master/L57-csharp-new-major-version.md

Updating this in Agoda.Frameworks.Grpc should allow users to start using new version of gRPC in C#. Both version 2.x and 1.x will be fully interoperable, so there's no changes required except for gRPC dependencies.