### PR TITLE
Unique cache key by client

### DIFF
--- a/Agoda.Frameworks.DB.Tests/DbRepositorySimplifiedTest.cs
+++ b/Agoda.Frameworks.DB.Tests/DbRepositorySimplifiedTest.cs
@@ -79,6 +79,31 @@ namespace Agoda.Frameworks.DB.Tests
         }
 
         [Test]
+        public async Task ExecuteQuerySingleAsync_Hit_Cache_By_Client_Key_Success()
+        {
+            SetupAsync();
+
+            var cacheKey = "client-key";
+            object cachedValue = "cachedValue";
+            _cache.Setup(x => x.TryGetValue(cacheKey, out cachedValue))
+                .Returns(true);
+            var result = await _db.ExecuteQuerySingleAsync<string>("mobile_ro", "db.v1.sp_foo", CommandType.StoredProcedure, new
+            {
+                param1 = "value1",
+                param2 = "value2"
+            },
+                TimeSpan.MaxValue, cacheKey);
+            Assert.AreEqual(cachedValue, result);
+
+            _cache.Verify(
+                x => x.TryGetValue(cacheKey, out cachedValue),
+                Times.Once);
+            _dbResources.Verify(x => x.ChooseDb("mobile_ro").SelectRandomly(), Times.Never);
+
+            Assert.AreEqual(0, _onQueryCompleteEvents.Count);
+        }
+
+        [Test]
         public async Task ExecuteReaderAsync_Hit_Cache_Success()
         {
             SetupAsync();

--- a/Agoda.Frameworks.DB.Tests/DbRepositorySimplifiedTest.cs
+++ b/Agoda.Frameworks.DB.Tests/DbRepositorySimplifiedTest.cs
@@ -1,11 +1,9 @@
-﻿using System;
+﻿using Moq;
+using NUnit.Framework;
+using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
-using Dapper;
-using Moq;
-using Moq.Dapper;
-using NUnit.Framework;
 
 namespace Agoda.Frameworks.DB.Tests
 {

--- a/Agoda.Frameworks.DB.Tests/DbRepositoryTest.cs
+++ b/Agoda.Frameworks.DB.Tests/DbRepositoryTest.cs
@@ -89,6 +89,28 @@ namespace Agoda.Frameworks.DB.Tests
         }
 
         [Test]
+        public void Query_Hit_Cache_By_Provide_Key_By_Client()
+        {
+            var clientKey = "client-key";
+
+            _cache.Setup(x => x.TryGetValue(It.IsAny<string>(), out _cacheRows))
+                .Returns(true);
+            var result = _db.Query(new FakeStoredProc
+            {
+                CacheLifetime = TimeSpan.MaxValue
+            }, "foo", clientKey);
+
+            Assert.AreEqual(_cacheRows, result);
+
+            _cache.Verify(
+                x => x.TryGetValue(clientKey, out _cacheRows),
+                Times.Once);
+            _dbResources.Verify(x => x.ChooseDb("mobile_ro").SelectRandomly(), Times.Never);
+
+            Assert.AreEqual(0, _onQueryCompleteEvents.Count);
+        }
+
+        [Test]
         public void Query_No_Cache_Lifetime()
         {
             _cache.Setup(x => x.TryGetValue(It.IsAny<string>(), out _cacheRows))

--- a/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
+++ b/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
@@ -3,7 +3,7 @@
     <Authors>Agoda</Authors>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Description>Agoda.Frameworks.DB</Description>
-    <VersionPrefix>7.0.87</VersionPrefix>
+    <VersionPrefix>7.0.88</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)'!='Windows_NT'">

--- a/Agoda.Frameworks.DB/DbRepository.cs
+++ b/Agoda.Frameworks.DB/DbRepository.cs
@@ -60,11 +60,12 @@ namespace Agoda.Frameworks.DB
         private TFuncResult ExecuteCacheOrGet<TRequest, TResult, TFuncResult>(
             IStoredProc<TRequest, TResult> sp,
             TRequest parameters,
-            Func<TFuncResult> getResultFunc)
+            Func<TFuncResult> getResultFunc,
+            string cacheKey = "")
         {
             return EnableCache(sp)
-                ? _cache.GetOrCreate(
-                    sp.GetParameters(parameters).CreateCacheKey(sp.StoredProcedureName),
+                ? _cache.GetOrCreate(string.IsNullOrEmpty(cacheKey) ?
+                    sp.GetParameters(parameters).CreateCacheKey(sp.StoredProcedureName) : cacheKey,
                     sp.CacheLifetime,
                     getResultFunc)
                 : getResultFunc();
@@ -73,11 +74,12 @@ namespace Agoda.Frameworks.DB
         private Task<TFuncResult> ExecuteCacheOrGetAsync<TRequest, TResult, TFuncResult>(
             IStoredProc<TRequest, TResult> sp,
             TRequest parameters,
-            Func<Task<TFuncResult>> getResultFunc)
+            Func<Task<TFuncResult>> getResultFunc,
+            string cacheKey = "")
         {
             return EnableCache(sp)
-                ? _cache.GetOrCreateAsync(
-                    sp.GetParameters(parameters).CreateCacheKey(sp.StoredProcedureName),
+                ? _cache.GetOrCreateAsync(string.IsNullOrEmpty(cacheKey) ?
+                    sp.GetParameters(parameters).CreateCacheKey(sp.StoredProcedureName): cacheKey,
                     sp.CacheLifetime,
                     getResultFunc)
                 : getResultFunc();
@@ -85,30 +87,34 @@ namespace Agoda.Frameworks.DB
 
         public IEnumerable<TResult> Query<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters)
+            TRequest parameters,
+            string cacheKey = "")
         {
-            return ExecuteCacheOrGet(sp, parameters, () => QueryImpl(sp, parameters));
+            return ExecuteCacheOrGet(sp, parameters, () => QueryImpl(sp, parameters), cacheKey);
         }
 
         public Task<IEnumerable<TResult>> QueryAsync<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters)
+            TRequest parameters,
+            string cacheKey = "")
         {
-            return ExecuteCacheOrGetAsync(sp, parameters, () => QueryAsyncImpl(sp, parameters));
+            return ExecuteCacheOrGetAsync(sp, parameters, () => QueryAsyncImpl(sp, parameters), cacheKey);
         }
 
         public TResult QueryMultiple<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters)
+            TRequest parameters,
+            string cacheKey = "")
         {
-            return ExecuteCacheOrGet(sp, parameters, () => QueryMultipleImpl(sp, parameters));
+            return ExecuteCacheOrGet(sp, parameters, () => QueryMultipleImpl(sp, parameters), cacheKey);
         }
 
         public Task<TResult> QueryMultipleAsync<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters)
+            TRequest parameters,
+            string cacheKey = "")
         {
-            return ExecuteCacheOrGetAsync(sp, parameters, () => QueryMultipleAsyncImpl(sp, parameters));
+            return ExecuteCacheOrGetAsync(sp, parameters, () => QueryMultipleAsyncImpl(sp, parameters), cacheKey);
         }
 
         public int ExecuteNonQuery<TRequest>(

--- a/Agoda.Frameworks.DB/DbRepositorySimplified.cs
+++ b/Agoda.Frameworks.DB/DbRepositorySimplified.cs
@@ -201,11 +201,12 @@ namespace Agoda.Frameworks.DB
             string sqlCommandString,
             IDbDataParameter[] parameters,
             Func<Task<TFuncResult>> getResultFunc,
-            TimeSpan? timeSpan)
+            TimeSpan? timeSpan,
+             string cacheKey = "")
         {
             return EnableCache(timeSpan)
-                ? _cache.GetOrCreateAsync(
-                    CreateCacheKey(sqlCommandString, parameters),
+                ? _cache.GetOrCreateAsync(string.IsNullOrEmpty(cacheKey) ?
+                    CreateCacheKey(sqlCommandString, parameters): cacheKey,
                     timeSpan,
                     getResultFunc)
                 : getResultFunc();

--- a/Agoda.Frameworks.DB/DbRepositorySimplified.cs
+++ b/Agoda.Frameworks.DB/DbRepositorySimplified.cs
@@ -22,11 +22,11 @@ namespace Agoda.Frameworks.DB
         }
 
         public Task<T> ExecuteReaderAsync<T>(string database, string storedProc, int timeoutSecs, int maxAttemptCount,
-            IDbDataParameter[] parameters, Func<SqlDataReader, Task<T>> callback, TimeSpan? timeSpan)
+            IDbDataParameter[] parameters, Func<SqlDataReader, Task<T>> callback, TimeSpan? timeSpan,string cacheKey = "")
         {
             return ExecuteCacheOrGetAsync(storedProc, parameters,
                 () => ExecuteReaderAsync(database, storedProc, timeoutSecs, maxAttemptCount, parameters, callback),
-                timeSpan);
+                timeSpan, cacheKey);
         }
 
         public async Task<object> ExecuteScalarAsync(
@@ -68,10 +68,12 @@ namespace Agoda.Frameworks.DB
             string sqlCommandString,
             CommandType commandType,
             object parameters,
-            TimeSpan? timeSpan)
+            TimeSpan? timeSpan,
+            string cacheKey = "")
         {
             return ExecuteCacheOrGetAsync(sqlCommandString, parameters,
-                () => ExecuteQueryAsync<T>(dbName, sqlCommandString, commandType, parameters), timeSpan);
+                    () => ExecuteQueryAsync<T>(dbName, sqlCommandString, commandType, parameters), 
+                    timeSpan, cacheKey);
         }
 
         public async Task<IEnumerable<T>> ExecuteQueryAsync<T>(
@@ -113,10 +115,11 @@ namespace Agoda.Frameworks.DB
             string sqlCommandString,
             CommandType commandType,
             object parameters,
-            TimeSpan? timeSpan)
+            TimeSpan? timeSpan,
+            string cacheKey = "")
         {
             return ExecuteCacheOrGetAsync(sqlCommandString, parameters,
-                () => ExecuteQuerySingleAsync<T>(dbName, sqlCommandString, commandType, parameters), timeSpan);
+                () => ExecuteQuerySingleAsync<T>(dbName, sqlCommandString, commandType, parameters), timeSpan, cacheKey);
         }
         
         public async Task<T> ExecuteQuerySingleAsync<T>(
@@ -184,11 +187,12 @@ namespace Agoda.Frameworks.DB
             string sqlCommandString,
             object parameters,
             Func<Task<TFuncResult>> getResultFunc,
-            TimeSpan? timeSpan)
+            TimeSpan? timeSpan,
+            string cacheKey ="")
         {
             return EnableCache(timeSpan)
-                ? _cache.GetOrCreateAsync(
-                    CreateCacheKey(sqlCommandString, parameters),
+                ? _cache.GetOrCreateAsync(string.IsNullOrEmpty(cacheKey)?
+                    CreateCacheKey(sqlCommandString, parameters): cacheKey,
                     timeSpan,
                     getResultFunc)
                 : getResultFunc();

--- a/Agoda.Frameworks.DB/IDbRepository.cs
+++ b/Agoda.Frameworks.DB/IDbRepository.cs
@@ -59,19 +59,23 @@ namespace Agoda.Frameworks.DB
 
         IEnumerable<TResult> Query<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters,string cacheKey);
+            TRequest parameters,
+            string cacheKey);
 
         Task<IEnumerable<TResult>> QueryAsync<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters,string cacheKey);
+            TRequest parameters,
+            string cacheKey);
 
         TResult QueryMultiple<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters,string cacheKey);
+            TRequest parameters,
+            string cacheKey);
 
         Task<TResult> QueryMultipleAsync<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters,string cacheKey);
+            TRequest parameters,
+            string cacheKey);
 
         /// <summary>
         /// Execute parameterized SQL

--- a/Agoda.Frameworks.DB/IDbRepository.cs
+++ b/Agoda.Frameworks.DB/IDbRepository.cs
@@ -59,19 +59,19 @@ namespace Agoda.Frameworks.DB
 
         IEnumerable<TResult> Query<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters);
+            TRequest parameters,string cacheKey);
 
         Task<IEnumerable<TResult>> QueryAsync<TRequest, TResult>(
             IStoredProc<TRequest, TResult> sp,
-            TRequest parameters);
+            TRequest parameters,string cacheKey);
 
         TResult QueryMultiple<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters);
+            TRequest parameters,string cacheKey);
 
         Task<TResult> QueryMultipleAsync<TRequest, TResult>(
             IMultipleStoredProc<TRequest, TResult> sp,
-            TRequest parameters);
+            TRequest parameters,string cacheKey);
 
         /// <summary>
         /// Execute parameterized SQL

--- a/Agoda.Frameworks.DB/IDbRepository.cs
+++ b/Agoda.Frameworks.DB/IDbRepository.cs
@@ -24,7 +24,8 @@ namespace Agoda.Frameworks.DB
             int maxAttemptCount,
             IDbDataParameter[] parameters,
             Func<SqlDataReader, Task<T>> callback,
-            TimeSpan? timeSpan);
+            TimeSpan? timeSpan,
+            string cacheKey);
         Task<object> ExecuteScalarAsync(
             string dbName,
             string sqlCommandString,
@@ -42,14 +43,16 @@ namespace Agoda.Frameworks.DB
             string sqlCommandString,
             CommandType commandType,
             object parameters,
-            TimeSpan? timeSpan);
+            TimeSpan? timeSpan,
+            string cacheKey);
 
         Task<T> ExecuteQuerySingleAsync<T>(
             string dbName,
             string sqlCommandString,
             CommandType commandType,
             object parameters,
-            TimeSpan? timeSpan);
+            TimeSpan? timeSpan,
+            string cacheKey);
         
         Task<T> ExecuteQuerySingleAsync<T>(
             string dbName,


### PR DESCRIPTION
Each cache key should preferably be unique to the query executed so that different methods do not end up unintentionally sharing the same data.

I need to construct a unique key that is left to the developer or client