### PR TITLE
Remove support for net framework 462

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0
+        dotnet-version: '6.0.x'
 
     - name: Restore
       run: dotnet restore
@@ -66,7 +66,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0
+          dotnet-version: '6.0.x'
 
       - name: Push to NuGet
         run: dotnet nuget push nupkg/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://nuget.org --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: master
 
+env:
+  MAJOR_MINOR_VERSION: 7.1.
+  SOLUTION_FILE: Agoda.LoadBalancing.sln
+
 jobs:
   build:
     name: Build Package 
@@ -16,7 +20,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 6.0
 
     - name: Restore
       run: dotnet restore
@@ -28,8 +32,13 @@ jobs:
     - name: Test
       run: dotnet test
 
-    - name: Pack
-      run: dotnet pack --configuration Release -o finalpackage --no-build
+    - name: Pack Release
+      if: github.ref == 'refs/heads/master'
+      run: dotnet pack ${{ env.SOLUTION_FILE }} --configuration Debug -o finalpackage --no-build -p:PackageVersion=${{ env.MAJOR_MINOR_VERSION }}${{ github.run_number }}
+
+    - name: Pack Preview
+      if: github.ref != 'refs/heads/master'
+      run: dotnet pack ${{ env.SOLUTION_FILE }} --configuration Debug -o finalpackage --no-build -p:PackageVersion=${{ env.MAJOR_MINOR_VERSION }}${{ github.run_number }}-preview
 
     - name: Publish artifact
       uses: actions/upload-artifact@master
@@ -57,7 +66,7 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.100
+          dotnet-version: 6.0
 
       - name: Push to NuGet
         run: dotnet nuget push nupkg/**/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://nuget.org --skip-duplicate

--- a/Agoda.Frameworks.DB.Tests/Agoda.Frameworks.DB.Tests.csproj
+++ b/Agoda.Frameworks.DB.Tests/Agoda.Frameworks.DB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
+++ b/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
@@ -3,6 +3,7 @@
     <Authors>Agoda</Authors>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Description>Agoda.Frameworks.DB</Description>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
+++ b/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
@@ -3,7 +3,6 @@
     <Authors>Agoda</Authors>
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Description>Agoda.Frameworks.DB</Description>
-    <VersionPrefix>7.0.89</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
+++ b/Agoda.Frameworks.DB/Agoda.Frameworks.DB.csproj
@@ -6,11 +6,8 @@
     <VersionPrefix>7.0.89</VersionPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Agoda.Frameworks.Grpc.Tests/Agoda.Frameworks.Grpc.Tests.csproj
+++ b/Agoda.Frameworks.Grpc.Tests/Agoda.Frameworks.Grpc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
+++ b/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
@@ -6,7 +6,6 @@
     <Product>Agoda.Frameworks.Grpc</Product>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.Grpc</Description>
-    <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
+++ b/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
@@ -9,11 +9,8 @@
     <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="Grpc.Core" Version="2.23.0" />

--- a/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
+++ b/Agoda.Frameworks.Grpc/Agoda.Frameworks.Grpc.csproj
@@ -6,6 +6,7 @@
     <Product>Agoda.Frameworks.Grpc</Product>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.Grpc</Description>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Http.AutoRestExt.Tests/Agoda.Frameworks.Http.AutoRestExt.Tests.csproj
+++ b/Agoda.Frameworks.Http.AutoRestExt.Tests/Agoda.Frameworks.Http.AutoRestExt.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
+++ b/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
@@ -8,11 +8,8 @@
     <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
+++ b/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
@@ -5,6 +5,7 @@
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.LoadBalancing</Description>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
+++ b/Agoda.Frameworks.Http.AutoRestExt/Agoda.Frameworks.Http.AutoRestExt.csproj
@@ -5,7 +5,6 @@
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.LoadBalancing</Description>
-    <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Http.Tests/Agoda.Frameworks.Http.Tests.csproj
+++ b/Agoda.Frameworks.Http.Tests/Agoda.Frameworks.Http.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
+++ b/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
@@ -6,6 +6,7 @@
     <Product>Agoda.Frameworks.Http</Product>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.Http</Description>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
+++ b/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
@@ -6,7 +6,6 @@
     <Product>Agoda.Frameworks.Http</Product>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.Http</Description>
-    <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
+++ b/Agoda.Frameworks.Http/Agoda.Frameworks.Http.csproj
@@ -9,11 +9,8 @@
     <VersionPrefix>7.0.83</VersionPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Agoda.Frameworks.LoadBalancing.Tests/Agoda.Frameworks.LoadBalancing.Tests.csproj
+++ b/Agoda.Frameworks.LoadBalancing.Tests/Agoda.Frameworks.LoadBalancing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
+++ b/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
@@ -8,11 +8,8 @@
     <VersionPrefix>7.0.84</VersionPrefix>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
+++ b/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
@@ -5,6 +5,7 @@
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.LoadBalancing</Description>
+	  <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
+++ b/Agoda.Frameworks.LoadBalancing/Agoda.Frameworks.LoadBalancing.csproj
@@ -5,7 +5,6 @@
     <PackageProjectUrl>https://github.com/agoda-com/net-loadbalancing</PackageProjectUrl>
     <Company>Agoda</Company>
     <Description>Agoda.Frameworks.LoadBalancing</Description>
-    <VersionPrefix>7.0.84</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We no longer use the old frameworks, and it takes additional IDE setup for people to work on it, so removing.