### PR TITLE
Add Headers into the requests

### DIFF
--- a/Agoda.Frameworks.Http/RandomUrlHttpClient.cs
+++ b/Agoda.Frameworks.Http/RandomUrlHttpClient.cs
@@ -111,15 +111,27 @@ namespace Agoda.Frameworks.Http
         public Task<HttpResponseMessage> DeleteAsync(string url) =>
             SendAsync(url, uri => HttpClient.DeleteAsync(uri));
 
+        private HttpRequestMessage AddHeaders(HttpRequestMessage requestMessage, Dictionary<string, string> headers = null)
+        {
+            foreach (var header in headers)
+            {
+                requestMessage.Headers.Add(header.Key, header.Value);
+            }
+            return requestMessage;
+        }
+
         public Task<HttpResponseMessage> SendAsync(
             string url,
-            Func<string, HttpRequestMessage> requestMsg) =>
-            SendAsync(url, uri => HttpClient.SendAsync(requestMsg(uri)));
+            Func<string, HttpRequestMessage> requestMsg,
+            Dictionary<string, string> headers = null) =>
+            SendAsync(url, uri => HttpClient.SendAsync(AddHeaders(requestMsg(uri), headers)));
+            
 
         public Task<IReadOnlyList<RetryActionResult<string, HttpResponseMessage>>> SendAsyncWithDiag(
             string url,
-            Func<string, HttpRequestMessage> requestMsg) =>
-            SendAsyncWithDiag(url, uri => HttpClient.SendAsync(requestMsg(uri)));
+            Func<string, HttpRequestMessage> requestMsg,
+            Dictionary<string, string> headers = null) =>
+            SendAsyncWithDiag(url, uri => HttpClient.SendAsync(AddHeaders(requestMsg(uri), headers)));
 
         private async Task<HttpResponseMessage> SendAsync(
             string url,

--- a/Agoda.Frameworks.Http/RandomUrlHttpClient.cs
+++ b/Agoda.Frameworks.Http/RandomUrlHttpClient.cs
@@ -119,19 +119,30 @@ namespace Agoda.Frameworks.Http
             }
             return requestMessage;
         }
-
+        
         public Task<HttpResponseMessage> SendAsync(
             string url,
             Func<string, HttpRequestMessage> requestMsg,
-            Dictionary<string, string> headers = null) =>
+            Dictionary<string, string> headers) =>
             SendAsync(url, uri => HttpClient.SendAsync(AddHeaders(requestMsg(uri), headers)));
             
 
         public Task<IReadOnlyList<RetryActionResult<string, HttpResponseMessage>>> SendAsyncWithDiag(
             string url,
             Func<string, HttpRequestMessage> requestMsg,
-            Dictionary<string, string> headers = null) =>
+            Dictionary<string, string> headers) =>
             SendAsyncWithDiag(url, uri => HttpClient.SendAsync(AddHeaders(requestMsg(uri), headers)));
+
+        public Task<HttpResponseMessage> SendAsync(
+            string url,
+            Func<string, HttpRequestMessage> requestMsg) =>
+            SendAsync(url, uri => HttpClient.SendAsync(requestMsg(uri)));
+            
+
+        public Task<IReadOnlyList<RetryActionResult<string, HttpResponseMessage>>> SendAsyncWithDiag(
+            string url,
+            Func<string, HttpRequestMessage> requestMsg) =>
+            SendAsyncWithDiag(url, uri => HttpClient.SendAsync(requestMsg(uri)));
 
         private async Task<HttpResponseMessage> SendAsync(
             string url,


### PR DESCRIPTION
Due to the client doesn't support adding request on functional level, only default headers. This MR proposed to add a new function on SendAsync to add a new additional headers on functional level. 

The use case we are facing is we have a website client that varies the queries on header level on every request or function to minimize the load on Main DB.