### PR TITLE
Throw request timeout exception when provided timeout expires

### DIFF
--- a/Agoda.Frameworks.Http.Tests/MockSetup/WaitedMockHttpMessageHandler.cs
+++ b/Agoda.Frameworks.Http.Tests/MockSetup/WaitedMockHttpMessageHandler.cs
@@ -1,0 +1,29 @@
+﻿using RichardSzalay.MockHttp;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Agoda.Frameworks.Http.Tests.MockSetup
+{
+    public class WaitedMockHttpMessageHandler : MockHttpMessageHandler
+    {
+        private readonly TimeSpan waitTime;
+
+        public WaitedMockHttpMessageHandler(TimeSpan waitTime, BackendDefinitionBehavior backendDefinitionBehavior = BackendDefinitionBehavior.NoExpectations)
+            : base(backendDefinitionBehavior)
+        {
+            this.waitTime = waitTime;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var timeoutTask = Task.Delay(waitTime, cancellationToken);
+            var respTask = base.SendAsync(request, cancellationToken);
+
+            await Task.WhenAll(timeoutTask, respTask);
+
+            return await respTask;
+        }
+    }
+}

--- a/Agoda.Frameworks.Http.Tests/RandomUrlHttpClientTest.cs
+++ b/Agoda.Frameworks.Http.Tests/RandomUrlHttpClientTest.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Agoda.Frameworks.Http;
+using Agoda.Frameworks.Http.Tests.MockSetup;
 using NUnit.Framework;
 using RichardSzalay.MockHttp;
 
@@ -166,6 +168,81 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
             // Should not throw due to identical items in the list (Distinct before ToDictionary)
             client.UpdateBaseUrls(new[] { "http://test/3", "http://test/3" });
             Assert.AreEqual("http://test/3", client.UrlResourceManager.SelectRandomly());
+        }
+
+        [Test]
+        public void ShouldThrowRequestTimeoutExceptionWhenHttpRequestTimesOut()
+        {
+            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 3));
+
+            mockHttp.When(HttpMethod.Get, "http://test/*")
+                .Respond(msg =>
+                {
+                    StringAssert.IsMatch("http://test/1|2/api/55", msg.RequestUri.AbsoluteUri);
+                    return new StringContent("ok");
+                });
+            var httpclient = mockHttp.ToHttpClient();
+
+            var client = new RandomUrlHttpClient(
+                httpclient,
+                new[] { "http://test/1", "http://test/2" },
+                new TimeSpan(0, 0, 1),
+                3,
+                null);
+
+            Assert.ThrowsAsync<RequestTimeoutException>(() => client.GetAsync("api/55"));
+        }
+
+        [Test]
+        public async Task ShouldNotThrowRequestTimeoutExceptionWhenHttpRequestDoesNotTimesOut()
+        {
+            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 1));
+
+            mockHttp.When(HttpMethod.Get, "http://test/*")
+                .Respond(msg =>
+                {
+                    StringAssert.IsMatch("http://test/1|2/api/55", msg.RequestUri.AbsoluteUri);
+                    return new StringContent("ok");
+                });
+            var httpclient = mockHttp.ToHttpClient();
+
+            var client = new RandomUrlHttpClient(
+                httpclient,
+                new[] { "http://test/1", "http://test/2" },
+                new TimeSpan(0, 0, 3),
+                3,
+                null);
+
+            var res = await client.GetAsync("api/55");
+            var content = await res.Content.ReadAsStringAsync();
+
+            Assert.AreEqual("ok", content);
+        }
+
+        [Test]
+        public async Task ShouldNotThrowRequestTimeoutExceptionWhenNoTimesOut()
+        {
+            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 1));
+
+            mockHttp.When(HttpMethod.Get, "http://test/*")
+                .Respond(msg =>
+                {
+                    StringAssert.IsMatch("http://test/1|2/api/55", msg.RequestUri.AbsoluteUri);
+                    return new StringContent("ok");
+                });
+            var httpclient = mockHttp.ToHttpClient();
+
+            var client = new RandomUrlHttpClient(
+                httpclient,
+                new[] { "http://test/1", "http://test/2" },
+                null,
+                3,
+                null);
+
+            var res = await client.GetAsync("api/55");
+            var content = await res.Content.ReadAsStringAsync();
+
+            Assert.AreEqual("ok", content);
         }
     }
 }

--- a/Agoda.Frameworks.Http.Tests/RandomUrlHttpClientTest.cs
+++ b/Agoda.Frameworks.Http.Tests/RandomUrlHttpClientTest.cs
@@ -173,7 +173,7 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
         [Test]
         public void ShouldThrowRequestTimeoutExceptionWhenHttpRequestTimesOut()
         {
-            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 3));
+            var mockHttp = new WaitedMockHttpMessageHandler(TimeSpan.FromMilliseconds(300));
 
             mockHttp.When(HttpMethod.Get, "http://test/*")
                 .Respond(msg =>
@@ -186,7 +186,7 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
             var client = new RandomUrlHttpClient(
                 httpclient,
                 new[] { "http://test/1", "http://test/2" },
-                new TimeSpan(0, 0, 1),
+                TimeSpan.FromMilliseconds(100),
                 3,
                 null);
 
@@ -196,7 +196,7 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
         [Test]
         public async Task ShouldNotThrowRequestTimeoutExceptionWhenHttpRequestDoesNotTimesOut()
         {
-            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 1));
+            var mockHttp = new WaitedMockHttpMessageHandler(TimeSpan.FromMilliseconds(100));
 
             mockHttp.When(HttpMethod.Get, "http://test/*")
                 .Respond(msg =>
@@ -209,7 +209,7 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
             var client = new RandomUrlHttpClient(
                 httpclient,
                 new[] { "http://test/1", "http://test/2" },
-                new TimeSpan(0, 0, 3),
+                TimeSpan.FromMilliseconds(300),
                 3,
                 null);
 
@@ -222,7 +222,7 @@ namespace Agoda.Frameworks.LoadBalancing.Tests
         [Test]
         public async Task ShouldNotThrowRequestTimeoutExceptionWhenNoTimesOut()
         {
-            var mockHttp = new WaitedMockHttpMessageHandler(new TimeSpan(0, 0, 1));
+            var mockHttp = new WaitedMockHttpMessageHandler(TimeSpan.FromMilliseconds(100));
 
             mockHttp.When(HttpMethod.Get, "http://test/*")
                 .Respond(msg =>


### PR DESCRIPTION
### Bug
`RandomUrlHttpClient` takes in timeout parameter and is expected to throw `TimeoutException` when the given timeout expires:
https://github.com/agoda-com/net-loadbalancing/blob/7f6386ff9082076243f4772c19cfea39ec11601d/Agoda.Frameworks.Http/RandomUrlHttpClient.cs#L189

However, the timeout exception is never thrown because the token is never passed to the HttpClient

### Fix
Pass CancellationToken to HttpClients for each `SendAsync` requests.