### PR TITLE
Fix Workflow with NuGet 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,6 @@ jobs:
           name: nupkg
           path: ./nupkg
 
-      # Empty commit to show that bugged 
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1
-        with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          nuget-version: latest
-
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           name: nupkg
           path: ./nupkg
 
+      # Empty commit to show that bugged 
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
         with:


### PR DESCRIPTION
Fix #53 

We can remove the `NuGet/setup-nuget@v1` step as it's not used in our workflow.

The push nuget uses `dotnet` command not nuget directly. 
And dotnet comes built in with the nuget push.